### PR TITLE
Make it easier to add or remove multiple packages w/ Vector{String}

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ These functions are intended to be used interactively when the Pkg REPL is not a
 (e.g. if you are in a notebook):
 
 - `status()` shows the Conda dependencies of the current project.
-- `add(pkg; version="", channel="")` adds/replaces a dependency.
-- `rm(pkg)` removes a dependency.
+- `add(pkg; version="", channel="")` adds/replaces a dependency or a vector of dependencies.
+- `rm(pkg)` removes a dependency or a vector of dependencies.
 - `add_channel(channel)` adds a channel.
 - `rm_channel(channel)` removes a channel.
 - `add_pip(pkg; version="")` adds/replaces a pip dependency.

--- a/test/main.jl
+++ b/test/main.jl
@@ -66,32 +66,25 @@ end
     include("setup.jl")
     CondaPkg.add("python", version="==3.10.2")
     # verify package isn't already installed
-    @test !occursin("numpy", status())
-    @test !occursin("scipy", status())
-    @test !occursin("matplotlib", status())
-    @test !occursin("h5py", status())
+    @test !occursin("jsonlines ", status())
+    @test !occursin("cowpy", status())
     CondaPkg.withenv() do
-        isnull || @test_throws Exception run(`python -c "import six"`)
+        isnull || @test_throws Exception run(`python -c "import jsonlines"`)
+        isnull || @test_throws Exception run(`python -c "import cowpy"`)
     end
 
     # install multiple packages
-    CondaPkg.add(["numpy", "scipy", "matplotlib", "h5py"])
-    @test occursin("numpy", status())
-    @test occursin("scipy", status())
-    @test occursin("matplotlib", status())
-    @test occursin("h5py", status())
+    CondaPkg.add(["jsonlines", "cowpy"])
+    @test occursin("jsonlines", status())
+    @test occursin("cowpy", status())
 
     # remove multiple packages
-    CondaPkg.rm(["numpy", "scipy", "matplotlib", "h5py"])
-    @test !occursin("numpy", status())
-    @test !occursin("scipy", status())
-    @test !occursin("matplotlib", status())
-    @test !occursin("h5py", status())
+    CondaPkg.rm(["jsonlines", "cowpy"])
+    @test !occursin("jsonlines ", status())
+    @test !occursin("cowpy", status())
     CondaPkg.withenv() do
         isnull || @test_throws Exception run(`python -c "import numpy"`)
-        isnull || @test_throws Exception run(`python -c "import scipy"`)
-        isnull || @test_throws Exception run(`python -c "import matplotlib"`)
-        isnull || @test_throws Exception run(`python -c "import h5py"`)
+        isnull || @test_throws Exception run(`python -c "import cowpy"`))
     end
 end
 

--- a/test/main.jl
+++ b/test/main.jl
@@ -54,6 +54,26 @@ end
     end
     @test occursin("v1.16.0", status()) == !isnull
 
+    # remove package
+    CondaPkg.rm("six")
+    @test !occursin("six", status())
+    CondaPkg.withenv() do
+        isnull || @test_throws Exception run(`python -c "import six"`)
+    end
+end
+
+@testitem "install/remove multiple python packages" begin
+    include("setup.jl")
+    CondaPkg.add("python", version="==3.10.2")
+    # verify package isn't already installed
+    @test !occursin("numpy", status())
+    @test !occursin("scipy", status())
+    @test !occursin("matplotlib", status())
+    @test !occursin("h5py", status())
+    CondaPkg.withenv() do
+        isnull || @test_throws Exception run(`python -c "import six"`)
+    end
+
     # install multiple packages
     CondaPkg.add(["numpy", "scipy", "matplotlib", "h5py"])
     @test occursin("numpy", status())
@@ -61,12 +81,13 @@ end
     @test occursin("matplotlib", status())
     @test occursin("h5py", status())
 
-    # remove package
+    # remove multiple packages
     CondaPkg.rm(["numpy", "scipy", "matplotlib", "h5py"])
-    CondaPkg.rm("six")
-    @test !occursin("six", status())
+    @test !occursin("numpy", status())
+    @test !occursin("scipy", status())
+    @test !occursin("matplotlib", status())
+    @test !occursin("h5py", status())
     CondaPkg.withenv() do
-        isnull || @test_throws Exception run(`python -c "import six"`)
         isnull || @test_throws Exception run(`python -c "import numpy"`)
         isnull || @test_throws Exception run(`python -c "import scipy"`)
         isnull || @test_throws Exception run(`python -c "import matplotlib"`)

--- a/test/main.jl
+++ b/test/main.jl
@@ -83,7 +83,7 @@ end
     @test !occursin("jsonlines ", status())
     @test !occursin("cowpy", status())
     CondaPkg.withenv() do
-        isnull || @test_throws Exception run(`python -c "import numpy"`)
+        isnull || @test_throws Exception run(`python -c "import jsonlines"`))
         isnull || @test_throws Exception run(`python -c "import cowpy"`))
     end
 end

--- a/test/main.jl
+++ b/test/main.jl
@@ -83,8 +83,8 @@ end
     @test !occursin("jsonlines ", status())
     @test !occursin("cowpy", status())
     CondaPkg.withenv() do
-        isnull || @test_throws Exception run(`python -c "import jsonlines"`))
-        isnull || @test_throws Exception run(`python -c "import cowpy"`))
+        isnull || @test_throws Exception run(`python -c "import jsonlines"`)
+        isnull || @test_throws Exception run(`python -c "import cowpy"`)
     end
 end
 

--- a/test/main.jl
+++ b/test/main.jl
@@ -54,11 +54,23 @@ end
     end
     @test occursin("v1.16.0", status()) == !isnull
 
+    # install multiple packages
+    CondaPkg.add(["numpy", "scipy", "matplotlib", "h5py"])
+    @test occursin("numpy", status())
+    @test occursin("scipy", status())
+    @test occursin("matplotlib", status())
+    @test occursin("h5py", status())
+
     # remove package
+    CondaPkg.rm(["numpy", "scipy", "matplotlib", "h5py"])
     CondaPkg.rm("six")
     @test !occursin("six", status())
     CondaPkg.withenv() do
         isnull || @test_throws Exception run(`python -c "import six"`)
+        isnull || @test_throws Exception run(`python -c "import numpy"`)
+        isnull || @test_throws Exception run(`python -c "import scipy"`)
+        isnull || @test_throws Exception run(`python -c "import matplotlib"`)
+        isnull || @test_throws Exception run(`python -c "import h5py"`)
     end
 end
 


### PR DESCRIPTION
Currently one cannot add or remove packages as indicated by a `Vector{String}` see #134

This pull request allows for the following syntax.

```
CondaPkg.add(["jsonlines", "cowpy"])
CondaPkg.rm(["jsonlines", "cowpy"])
```

It implements this by creating a function `_to_spec` with two methods.
For an existing `*Spec`, it just returns the spec. For an `AbstractString`,
it returns a `PkgSpec`.
