### PR TITLE
Align openssl version with OpenSSL_jll version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Pip packages are now installed using [`uv`](https://pypi.org/project/uv/) if it is installed.
+* Special handling of `openssl` for compatibility with `OpenSSL_jll` if it is installed.
 
 ## 0.2.22 (2023-10-20)
 * `pkg> conda run conda ...` now runs whatever conda executable CondaPkg is configured with.

--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,9 @@ TOML = "1"
 julia = "1.6"
 
 [extras]
+OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Test", "TestItemRunner"]
+test = ["OpenSSL_jll", "Test", "TestItemRunner"]

--- a/test/main.jl
+++ b/test/main.jl
@@ -142,6 +142,15 @@ end
     @test true
 end
 
+@testitem "install/remove opensll" begin
+    include("setup.jl")
+    CondaPkg.add("openssl", version="<=julia", resolve=false)
+    CondaPkg.resolve(force=true)
+    CondaPkg.rm("openssl", resolve=false)
+    CondaPkg.resolve(force=true)
+    @test true
+end
+
 @testitem "external conda env" begin
     include("setup.jl")
     dn = string(tempname(), backend, Sys.KERNEL, VERSION)


### PR DESCRIPTION
As suggested by @cjdoris on discourse, I implemented a similar version bound adaption for `OpenSSL_jll` as is already used for `libstdc++`.

The main things that I am uncertain about is:
- Can we trust that all openssl versions within the same minor version are compatible as I did in this PR? They don't seem to be following semver (?)
- `Pkg.dependencies()` is considered experimental so we may not want to rely on it. ~~Alternatively, we could rely on `Pkg.installed()` which is deprecated.~~ Actually, `Pkg.installed()` does not consider transitive dependencies so the only other option I can think of is to the `Manifest.toml` manually (?)

x-ref:
- https://discourse.julialang.org/t/pythoncall-ssl-verify-error-when-calling-pd-read-csv/115922/2
- https://github.com/JuliaPy/PythonCall.jl/issues/519