### PR TITLE
Add JULIA_CONDAPKG_UNSAFE_PARALLEL environment variable. Useful for (unsafe) skipping resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add `pip_backend` preference.
+* Add `JULIA_CONDAPKG_UNSAFE_PARALLEL` environment variable to (unsafe) skip resolving, which is necessary to load in parallel or in read only environments.
 
 ## 0.2.23 (2024-07-20)
 * Pip packages are now installed using [`uv`](https://pypi.org/project/uv/) if it is installed.

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -521,7 +521,7 @@ function resolve(;
     # skip resolving if already resolved and LOAD_PATH unchanged
     # this is a very fast check which avoids touching the file system
     load_path = Base.load_path()
-    if !force && STATE.resolved && STATE.load_path == load_path
+    if (!force && STATE.resolved && STATE.load_path == load_path) || unsafe_skip_resolve()
         @debug "already resolved (fast path)"
         interactive && _log(io, "Dependencies already up to date (resolved)")
         return
@@ -725,4 +725,8 @@ end
 
 function update()
     resolve(force = true, interactive = true)
+end
+
+function unsafe_skip_resolve()
+    getpref(Bool, "unsafe_skip_resolve", "JULIA_CONDAPKG_UNSAFE_SKIP_RESOLVE", false)
 end

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -559,8 +559,8 @@ function resolve(;
     meta_file = joinpath(meta_dir, "meta")
     lock_file = joinpath(meta_dir, "lock")
     # grap a file lock so only one process can resolve this environment at a time
-    mkpath(meta_dir)
     if !unsafe_skip_resolve()
+        mkpath(meta_dir)
         lock = try
             Pidfile.mkpidlock(lock_file; wait = false)
         catch
@@ -570,7 +570,8 @@ function resolve(;
     end
     try
         # skip resolving if nothing has changed since the metadata was updated
-        if !force && _resolve_can_skip_1(conda_env, load_path, meta_file)
+        if (!force && _resolve_can_skip_1(conda_env, load_path, meta_file)) ||
+           unsafe_skip_resolve()
             @debug "already resolved"
             STATE.resolved = true
             interactive && _log(io, "Dependencies already up to date")

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -521,7 +521,7 @@ function resolve(;
     # skip resolving if already resolved and LOAD_PATH unchanged
     # this is a very fast check which avoids touching the file system
     load_path = Base.load_path()
-    if (!force && STATE.resolved && STATE.load_path == load_path) || unsafe_skip_resolve()
+    if !force && STATE.resolved && STATE.load_path == load_path
         @debug "already resolved (fast path)"
         interactive && _log(io, "Dependencies already up to date (resolved)")
         return
@@ -561,7 +561,7 @@ function resolve(;
     # grap a file lock so only one process can resolve this environment at a time
     mkpath(meta_dir)
     lock = try
-        Pidfile.mkpidlock(lock_file; wait = false)
+        unsafe_skip_resolve() || Pidfile.mkpidlock(lock_file; wait = false)
     catch
         @info "CondaPkg: Waiting for lock to be freed. You may delete this file if no other process is resolving." lock_file
         Pidfile.mkpidlock(lock_file; wait = true)

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -560,7 +560,7 @@ function resolve(;
     lock_file = joinpath(meta_dir, "lock")
     # grap a file lock so only one process can resolve this environment at a time
     mkpath(meta_dir)
-    if unsafe_skip_resolve()
+    if !unsafe_skip_resolve()
         lock = try
             Pidfile.mkpidlock(lock_file; wait = false)
         catch


### PR DESCRIPTION
This can be useful/necessary when trying to load a CondaPkg.jl environment in parallel or in a read-only environment.

This resolves my problem #153. However, I'm not sure if you are okay with having such an unsafe option. In case you are and have feedback on how to improve my (rudimentary) way of implementing it, I would be happy to work on it more.