### PR TITLE
New prefs: libstdcxx_ng_version and openssl_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Add `pip_backend` preference.
+* Add `libstdcxx_ng_version` preference.
+* Add `openssl_version` preference.
 
 ## 0.2.23 (2024-07-20)
 * Pip packages are now installed using [`uv`](https://pypi.org/project/uv/) if it is installed.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ in more detail.
 | `env` | `JULIA_CONDAPKG_ENV` | Path to the Conda environment to use. |
 | `verbosity` | `JULIA_CONDAPKG_VERBOSITY` | One of `-1`, `0`, `1` or `2`. |
 | `pip_backend` | `JULIA_CONDAPKG_PIP_BACKEND` | One of `pip` or `uv`. |
+| `libstdcxx_ng_version` | `JULIA_CONDAPKG_LIBSTDCXX_NG_VERSION` | Either `ignore` or a version specifier. |
+| `openssl_version` | `JULIA_CONDAPKG_OPENSSL_VERSION` | Either `ignore` or a version specifier. |
 
 The easiest way to set these preferences is with the
 [`PreferenceTools`](https://github.com/cjdoris/PreferenceTools.jl)
@@ -226,6 +228,23 @@ You can control which package manager is used to install pip dependencies by set
 `pip_backend` preference to one of:
 - `pip`
 - `uv` (the default).
+
+### Compatibility between Julia and Conda packages
+
+If you use both a Julia package and a Conda package which both use the same underlying
+shared library, there can be compatibility issues if they are at different versions.
+
+To alleviate this, CondaPkg handles some packages specially. For the following Conda
+packages, if the version is set to `<=julia`, then a version of that package compatible
+with the corresponding Julia package will be installed.
+- `libstdcxx-ng`: Compatible with libstdcxx in `Base`.
+- `openssl`: Compatible with `OpenSSL_jll` (if installed).
+
+You can override this behaviour with the `libstdcxx_ng_version` and `openssl_version`
+preferences. These can be set to one of:
+- A (non-empty) specific Conda version specifier.
+- `ignore` to ignore the compatibility constraint entirely.
+- Unset or the empty string for the default behaviour.
 
 ## Frequently Asked Questions
 

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -104,20 +104,31 @@ Version of libstdcxx-ng compatible with the libstdc++ loaded into Julia.
 Specifying the package "libstdcxx-ng" with version "<=julia" will replace the version with
 this one. This should be used by anything which embeds Python into the Julia process - for
 instance it is used by PythonCall.
+
+Overridden by the `libstdcxx_ng_version` preference.
 """
 function _compatible_libstdcxx_ng_version()
+    bound =
+        getpref(String, "libstdcxx_ng_version", "JULIA_CONDAPKG_LIBSTDCXX_NG_VERSION", "")
+    if bound == "ignore"
+        return nothing
+    elseif bound != ""
+        return bound
+    end
     if !Sys.islinux()
-        return
+        return nothing
     end
     loaded_libstdcxx_version = Base.BinaryPlatforms.detect_libstdcxx_version()
     if loaded_libstdcxx_version === nothing
-        return
+        return nothing
     end
+    @debug "found libstdcxx $(loaded_libstdcxx_version)"
     for (version, bound) in _compatible_libstdcxx_ng_versions
         if loaded_libstdcxx_version ≥ version
             return bound
         end
     end
+    return nothing
 end
 
 """
@@ -126,8 +137,16 @@ end
 Find the version that aligns with the installed `OpenSSL_jll` version, if any.
 
 See https://www.openssl.org/policies/releasestrat.html.
+
+Overridden by the `openssl_version` preference.
 """
 function _compatible_openssl_version()
+    bound = getpref(String, "openssl_version", "JULIA_CONDAPKG_OPENSSL_VERSION", "")
+    if bound == "ignore"
+        return nothing
+    elseif bound != ""
+        return bound
+    end
     deps = Pkg.dependencies()
     uuid = Base.UUID("458c3c95-2e84-50aa-8efc-19380b2a3a95")
     dep = get(deps, uuid, nothing)

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -77,8 +77,11 @@ _convert(::Type{T}, @nospecialize(x)) where {T} = convert(T, x)::T
 # B is a compatible bound for libstdcxx_ng.
 # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html.
 # See https://gcc.gnu.org/develop.html#timeline.
+# Last updated: 2024-11-08
 const _compatible_libstdcxx_ng_versions = [
-    (v"3.4.31", ">=3.4,<=13.1"),
+    (v"3.4.33", ">=3.4,<14.3"),
+    (v"3.4.32", ">=3.4,<14.0"),
+    (v"3.4.31", ">=3.4,<13.2"),
     (v"3.4.30", ">=3.4,<13.0"),
     (v"3.4.29", ">=3.4,<12.0"),
     (v"3.4.28", ">=3.4,<11.0"),

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -59,3 +59,67 @@ end
         @test CondaPkg.abspathurl("/Foo/bar.TXT") == "file:///Foo/bar.TXT"
     end
 end
+
+@testitem "_compatible_libstdcxx_ng_version" begin
+    include("setup.jl")
+    key = "JULIA_CONDAPKG_LIBSTDCXX_NG_VERSION"
+    orig_bound = pop!(ENV, key, nothing)
+    try
+        @testset "$new_bound" for new_bound in [nothing, "", "foo"]
+            if new_bound === nothing
+                delete!(ENV, key)
+            else
+                ENV[key] = new_bound
+            end
+            bound = CondaPkg._compatible_libstdcxx_ng_version()
+            if new_bound === nothing || new_bound == ""
+                if Sys.islinux()
+                    if bound !== nothing
+                        @test bound isa String
+                        @test startswith(bound, ">=")
+                    end
+                else
+                    @test bound === nothing
+                end
+            else
+                @test bound == new_bound
+            end
+        end
+    finally
+        if orig_bound === nothing
+            delete!(ENV, key)
+        else
+            ENV[key] = orig_bound
+        end
+    end
+end
+
+@testitem "_compatible_openssl_version" begin
+    include("setup.jl")
+    key = "JULIA_CONDAPKG_OPENSSL_VERSION"
+    orig_bound = pop!(ENV, key, nothing)
+    try
+        @testset "$new_bound" for new_bound in [nothing, "", "foo"]
+            if new_bound === nothing
+                delete!(ENV, key)
+            else
+                ENV[key] = new_bound
+            end
+            bound = CondaPkg._compatible_openssl_version()
+            if new_bound === nothing || new_bound == ""
+                if bound !== nothing
+                    @test bound isa String
+                    @test startswith(bound, ">=")
+                end
+            else
+                @test bound == new_bound
+            end
+        end
+    finally
+        if orig_bound === nothing
+            delete!(ENV, key)
+        else
+            ENV[key] = orig_bound
+        end
+    end
+end


### PR DESCRIPTION
These let you override the automatic compatibility bounds for these conda packages.