### PR TITLE
Fix pixi spec for local package paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+* Bug fix: pip packages specified by file location are now correctly converted to "path"
+  installs with Pixi.
+
 ## 0.2.30 (2025-08-19)
 * `build=**cpython**` functionality updated for newer build strings in conda-forge.
 * Special handling of `libstdcxx` for compatibility with Julia's `libstdc++.so`, plus

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -157,7 +157,8 @@ function _compatible_libstdcxx_ng_version()
     if !Sys.islinux()
         return nothing
     end
-    loaded_libstdcxx_version = Base.BinaryPlatforms.detect_libstdcxx_version(_libstdcxx_max_minor_version)
+    loaded_libstdcxx_version =
+        Base.BinaryPlatforms.detect_libstdcxx_version(_libstdcxx_max_minor_version)
     if loaded_libstdcxx_version === nothing
         return nothing
     end
@@ -463,6 +464,20 @@ function abspathurl(args...)
         @assert startswith(path, "/")
     end
     return "file://$path"
+end
+
+# Inverse of abspathurl: convert a file:// URL (as produced by abspathurl) back to a local path
+function pathfromurl(url::AbstractString)
+    startswith(url, "file://") || error("not a file:// url: $url")
+    # strip the "file://" prefix
+    path = url[8:end]
+    if Sys.iswindows()
+        # abspathurl on Windows prepends a leading "/" before "C:/...".
+        startswith(path, "/") || error("not supported")
+        path = path[2:end]
+        path = replace(path, '/' => '\\')
+    end
+    return path
 end
 
 function _resolve_merge_pip_packages(packages)

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -225,6 +225,8 @@ function pixispec(x::PipPkgSpec)
             else
                 spec["git"] = url
             end
+        elseif startswith(url, "file:///")
+            spec["path"] = url[9:end]
         else
             spec["url"] = url
         end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -226,7 +226,7 @@ function pixispec(x::PipPkgSpec)
                 spec["git"] = url
             end
         elseif startswith(url, "file:///")
-            spec["path"] = url[9:end]
+            spec["path"] = pathfromurl(url)
         else
             spec["url"] = url
         end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -60,6 +60,51 @@ end
     end
 end
 
+@testitem "pathfromurl" begin
+    include("setup.jl")
+    if Sys.iswindows()
+        @test CondaPkg.pathfromurl("file:///C:/foo/bar.txt") == "C:\\foo\\bar.txt"
+    else
+        @test CondaPkg.pathfromurl("file:///foo/bar.txt") == "/foo/bar.txt"
+    end
+end
+
+@testitem "pixispec" begin
+    include("setup.jl")
+    @testset "$(case.args)" for case in [
+        (args = (), expected = "*"),
+        (args = (version = "=1.2.3",), expected = "=1.2.3"),
+        (
+            args = (extras = ["bar", "baz"],),
+            expected = Dict("extras" => ["bar", "baz"], "version" => "*"),
+        ),
+        (
+            args = (version = "@git+https://github.com/example/example.git",),
+            expected = Dict("git" => "https://github.com/example/example.git"),
+        ),
+        (
+            args = (version = "@git+https://github.com/example/example.git@rev",),
+            expected = Dict(
+                "git" => "https://github.com/example/example.git",
+                "rev" => "rev",
+            ),
+        ),
+        (
+            args = (version = "@git+https://github.com/example/example.git@tag#rev",),
+            expected = Dict(
+                "git" => "https://github.com/example/example.git",
+                "rev" => "rev",
+            ),
+        ),
+        (
+            args = (version = Sys.iswindows() ? "@file:///C:/foo" : "@file:///foo",),
+            expected = Dict("path" => Sys.iswindows() ? "C:\\foo" : "/foo"),
+        ),
+    ]
+        @test CondaPkg.pixispec(CondaPkg.PipPkgSpec("foo"; case.args...)) == case.expected
+    end
+end
+
 @testitem "_resolve_merge_versions" begin
     include("setup.jl")
     @testset "$(case.v1) $(case.v2)" for case in [


### PR DESCRIPTION
For local package files `path` must be used instead of `url` https://pixi.sh/v0.33.0/reference/project_configuration/#path