### PR TITLE
feat(resolve): add libstdcxx <=julia compatibility and preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * `build=**cpython**` functionality updated for newer build strings in conda-forge.
+* Special handling of `libstdcxx` for compatibility with Julia's `libstdc++.so`, plus
+  corresponding `libstdcxx_version` preference.
 
 ## 0.2.29 (2025-05-14)
 * Bug fix: detect actual libstdcxx version.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ in more detail.
 | `channel_priority` | `JULIA_CONDAPKG_CHANNEL_PRIORITY` | One of `strict`, `flexible` (default) or `disabled`. |
 | `channel_order` | `JULIA_CONDAPKG_CHANNEL_ORDER` | List specifying channel order, with optional `...` for other channels. |
 | `channel_mapping` | `JULIA_CONDAPKG_CHANNEL_MAPPING` | Map of channel names to rename (old->new). |
+| `libstdcxx_version` | `JULIA_CONDAPKG_LIBSTDCXX_VERSION` | Either `ignore` or a version specifier. |
 | `libstdcxx_ng_version` | `JULIA_CONDAPKG_LIBSTDCXX_NG_VERSION` | Either `ignore` or a version specifier. |
 | `openssl_version` | `JULIA_CONDAPKG_OPENSSL_VERSION` | Either `ignore` or a version specifier. |
 
@@ -292,11 +293,12 @@ shared library, there can be compatibility issues if they are at different versi
 To alleviate this, CondaPkg handles some packages specially. For the following Conda
 packages, if the version is set to `<=julia`, then a version of that package compatible
 with the corresponding Julia package will be installed.
-- `libstdcxx-ng`: Compatible with libstdcxx in `Base`.
+- `libstdcxx`: Compatible with libstdc++ in `Base`.
+- `libstdcxx-ng`: Compatible with libstdc++ in `Base`.
 - `openssl`: Compatible with `OpenSSL_jll` (if installed).
 
-You can override this behaviour with the `libstdcxx_ng_version` and `openssl_version`
-preferences. These can be set to one of:
+You can override this behaviour with the `libstdcxx_version`, `libstdcxx_ng_version` and
+`openssl_version` preferences. These can be set to one of:
 - A (non-empty) specific Conda version specifier.
 - `ignore` to ignore the compatibility constraint entirely.
 - Unset or the empty string for the default behaviour.

--- a/src/CondaPkg.jl
+++ b/src/CondaPkg.jl
@@ -84,6 +84,8 @@ getpref_exe() = getpref(String, "exe", "JULIA_CONDAPKG_EXE", "")
 getpref_env() = getpref(String, "env", "JULIA_CONDAPKG_ENV", "")
 getpref_libstdcxx_ng_version() =
     getpref(String, "libstdcxx_ng_version", "JULIA_CONDAPKG_LIBSTDCXX_NG_VERSION", "")
+getpref_libstdcxx_version() =
+    getpref(String, "libstdcxx_version", "JULIA_CONDAPKG_LIBSTDCXX_VERSION", "")
 getpref_openssl_version() =
     getpref(String, "openssl_version", "JULIA_CONDAPKG_OPENSSL_VERSION", "")
 getpref_verbosity() = getpref(Int, "verbosity", "JULIA_CONDAPKG_VERBOSITY", 0)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -93,6 +93,26 @@ end
     end
 end
 
+@testitem "_compatible_libstdcxx_version" begin
+    include("setup.jl")
+    @testset "$new_bound" for new_bound in [nothing, "", "foo"]
+        CondaPkg.STATE.test_preferences["libstdcxx_version"] = new_bound
+        bound = CondaPkg._compatible_libstdcxx_version()
+        if new_bound === nothing || new_bound == ""
+            if Sys.islinux()
+                if bound !== nothing
+                    @test bound isa String
+                    @test startswith(bound, ">=")
+                end
+            else
+                @test bound === nothing
+            end
+        else
+            @test bound == new_bound
+        end
+    end
+end
+
 @testitem "_compatible_openssl_version" begin
     include("setup.jl")
     @testset "$new_bound" for new_bound in [nothing, "", "foo"]

--- a/test/main.jl
+++ b/test/main.jl
@@ -189,6 +189,15 @@ end
     @test true
 end
 
+@testitem "install/remove libstdcxx" begin
+    include("setup.jl")
+    CondaPkg.add("libstdcxx", version = "<=julia", resolve = false)
+    CondaPkg.resolve(force = true)
+    CondaPkg.rm("libstdcxx", resolve = false)
+    CondaPkg.resolve(force = true)
+    @test true
+end
+
 @testitem "install/remove openssl" begin
     include("setup.jl")
     CondaPkg.add("openssl", version = "<=julia", resolve = false)


### PR DESCRIPTION
Extend special handling to the "libstdcxx" package, allowing version "<=julia" to resolve to a libstdc++ version compatible with the one loaded by Julia (Linux only). This mirrors existing behavior for "libstdcxx-ng" and helps embedding scenarios (e.g. PythonCall).

Introduce the libstdcxx_version preference (and
JULIA_CONDAPKG_LIBSTDCXX_VERSION env var) to override or ignore the compatibility constraint.

Update resolve logic, add internal and integration tests, and expand README with the new option and behavior.

Fixes #192 